### PR TITLE
javdb水印封面源替换，nfo内容优化，影片简介源修复。

### DIFF
--- a/core/scrapinglib/custom/storyline.py
+++ b/core/scrapinglib/custom/storyline.py
@@ -87,16 +87,19 @@ def getStoryline_mp(args):
 def getStoryline_airav(number):
     try:
         site = secrets.choice(('airav.cc','airav4.club'))
-        url = f'https://{site}/searchresults.aspx?Search={number}&Type=0'
+        url = f'https://{site}/searchresults.aspx?type=0&Search={number}'
         session = request_session()
         res = session.get(url)
         if not res:
             raise ValueError(f"get_html_by_session('{url}') failed")
         lx = fromstring(res.text)
-        urls = lx.xpath('//div[@class="resultcontent"]/ul/li/div/a[@class="ga_click"]/@href')
-        txts = lx.xpath('//div[@class="resultcontent"]/ul/li/div/a[@class="ga_click"]/h3[@class="one_name ga_name"]/text()')
+        urls = lx.xpath('//div[@id="testHcsticky"]/div/ul/li/div/a[@class="ga_click"]/@href')
+        txts = lx.xpath('//div[@id="testHcsticky"]/div/ul/li/div/a[@class="ga_click"]/h3[@class="one_name ga_name"]/text()')
         detail_url = None
         for txt, url in zip(txts, urls):
+            logger.info(f"Storyline found: {txt}")
+            if re.search("馬賽克破", txt):
+                continue
             if re.search(number, txt, re.I):
                 detail_url = urljoin(res.url, url)
                 break
@@ -110,7 +113,9 @@ def getStoryline_airav(number):
         airav_number = str(re.findall(r'^\s*\[(.*?)]', t)[0])
         if not re.search(number, airav_number, re.I):
             raise ValueError(f"page number ->[{airav_number}] not match")
-        desc = str(lx.xpath('//span[@id="ContentPlaceHolder1_Label2"]/text()')[0]).strip()
+        d1 = str(lx.xpath('//span[@itemprop="description"]/text()')[0])
+        logger.debug(f"Storyline description: {d1}")
+        desc = str(lx.xpath('//span[@itemprop="description"]/text()')[0]).strip()
         return desc
     except Exception as e:
         logger.debug(f"MP getStoryline_airav Error: {e},number [{number}].")


### PR DESCRIPTION
修改内容：
1. 使用javday.tv源更换javdb带水印的图片，并默认截取右半部分作为海报图（有码影片）；
2. thumb字段也使用poster.jpg，这样可以删除一张重复的thumb.jpg；
3. 使用番号精简nfo文件中sorttitle字段内容（根据kodi文档，该字段用于排序）；
4. runtime字段仅保留数字，默认单位分钟；
5. 修复airav源的影片简介获取。